### PR TITLE
Clear bower cache on each deploy

### DIFF
--- a/post-build
+++ b/post-build
@@ -8,7 +8,7 @@ BOWERSCRIPT="
 cd /app
 PATH=\$PATH:/app/vendor/node/bin
 if [[ -f ./bower.json ]]; then
-	npm install -g bower && bower install --allow-root
+	npm install -g bower && bower cache clean && bower install --allow-root
 fi
 "
 


### PR DESCRIPTION
I think that it'd be a good idea to clear bower cache on each install in case dependencies updated and the bower file has a `.x` in the dependency listing. 
