### PR TITLE
add /app/.heroku/node/bin to PATH

### DIFF
--- a/post-build
+++ b/post-build
@@ -6,7 +6,7 @@ BOWERSCRIPT="
 #!/bin/bash
 
 cd /app
-PATH=\$PATH:/app/vendor/node/bin
+PATH=\$PATH:/app/vendor/node/bin:/app/.heroku/node/bin
 if [[ -f ./bower.json ]]; then
 	npm install -g bower && bower install --allow-root
 fi


### PR DESCRIPTION
My buildpack puts node and npm in /app/.heroku, not /app/vendor.
This tiny change makes life simpler.  It should not affect any current users.
